### PR TITLE
Fix ignore_mask bounds

### DIFF
--- a/internal/compositor/compositor.go
+++ b/internal/compositor/compositor.go
@@ -15,7 +15,7 @@ func getBounds(v *magica.VoxelObject, ignoreMask bool) geometry.Bounds {
 	max := geometry.Point{}
 
 	if ignoreMask {
-		return geometry.Bounds{Min: max, Max: min}
+		return geometry.Bounds{Min: max, Max: geometry.Point{X: v.Size.X - 1, Y: v.Size.Y - 1, Z: v.Size.Z - 1}}
 	}
 
 	iterator := func(x, y, z int) {


### PR DESCRIPTION
Hi,

I noticed that the bounds has an off-by-one error when `ignore_mask` is enabled. This patch fixes the problem.