### PR TITLE
Support various new blending modes

### DIFF
--- a/internal/compositor/batch.go
+++ b/internal/compositor/batch.go
@@ -45,6 +45,7 @@ type Operation struct {
 	Scale             geometry.PointF `json:"scale"`
 	BoundingVolume    BoundingVolume  `json:"bounding_volume"`
 	Overwrite         bool            `json:"overwrite"`
+	BlendMode         string          `json:"blend_mode"`
 	Layers            []int           `json:"layers"`
 }
 
@@ -181,7 +182,7 @@ func (b *Batch) Run(outputDirectory, voxelDirectory string) (err error) {
 				if err != nil {
 					return fmt.Errorf("error opening voxel file %s: %v", voxelDirectory+op.File, err)
 				}
-				output := AddRepeated(input, src, op.N, op.InputColourRamps, op.OutputColourRamps, op.Overwrite, op.IgnoreMask, op.Truncate, op.MaskOriginal, op.MaskNew, op.FlipX)
+				output := AddRepeated(input, src, op.N, op.InputColourRamps, op.OutputColourRamps, op.Overwrite, op.BlendMode, op.IgnoreMask, op.Truncate, op.MaskOriginal, op.MaskNew, op.FlipX)
 				if err := saveFile(&output, outputFileName); err != nil {
 					return err
 				}

--- a/internal/compositor/compositor.go
+++ b/internal/compositor/compositor.go
@@ -223,7 +223,7 @@ func AddScaled(dst magica.VoxelObject, src magica.VoxelObject, inputRamps, outpu
 }
 
 // AddRepeated repeats a cargo object across the cargo area up to n times
-func AddRepeated(v magica.VoxelObject, originalSrc magica.VoxelObject, n int, inputRamps, outputRamps []string, overwrite bool, ignoreMask bool, ignoreTruncation bool, maskOriginal bool, maskNew bool, flipX bool) (r magica.VoxelObject) {
+func AddRepeated(v magica.VoxelObject, originalSrc magica.VoxelObject, n int, inputRamps, outputRamps []string, overwrite bool, blendMode string, ignoreMask bool, ignoreTruncation bool, maskOriginal bool, maskNew bool, flipX bool) (r magica.VoxelObject) {
 	r = v.Copy()
 
 	dstBounds := getBounds(&r, ignoreMask)
@@ -283,7 +283,7 @@ func AddRepeated(v magica.VoxelObject, originalSrc magica.VoxelObject, n int, in
 				if sx < 0 || sx >= srcSize.X {
 					r.Voxels[x][y][z] = 0
 				} else {
-					if !overwrite || src.Voxels[sx][sy][sz] != 0 {
+					if !overwrite || src.Voxels[sx][sy][sz] != 0 || blendMode == "in" || blendMode == "out" {
 						if maskNew {
 							if src.Voxels[sx][sy][sz] == 0 {
 								r.Voxels[x][y][z] = 0
@@ -291,7 +291,32 @@ func AddRepeated(v magica.VoxelObject, originalSrc magica.VoxelObject, n int, in
 								r.Voxels[x][y][z] = 255
 							}
 						} else {
-							r.Voxels[x][y][z] = src.Voxels[sx][sy][sz]
+							if blendMode == "in" {
+								if r.Voxels[x][y][z] != 0 && src.Voxels[sx][sy][sz] != 0 {
+									r.Voxels[x][y][z] = src.Voxels[sx][sy][sz]
+								} else {
+									r.Voxels[x][y][z] = 0
+								}
+							} else if blendMode == "out" {
+								if r.Voxels[x][y][z] == 0 && src.Voxels[sx][sy][sz] != 0 {
+									r.Voxels[x][y][z] = src.Voxels[sx][sy][sz]
+								} else {
+									r.Voxels[x][y][z] = 0
+								}
+							} else if blendMode == "atop" {
+								if r.Voxels[x][y][z] != 0 {
+									r.Voxels[x][y][z] = src.Voxels[sx][sy][sz]
+								}
+							} else if blendMode == "xor" {
+								if r.Voxels[x][y][z] != 0 {
+									r.Voxels[x][y][z] = 0
+								} else {
+									r.Voxels[x][y][z] = src.Voxels[sx][sy][sz]
+								}
+							} else {
+								// default to "over" mode
+								r.Voxels[x][y][z] = src.Voxels[sx][sy][sz]
+							}
 						}
 					}
 				}


### PR DESCRIPTION
This adds various blending modes using terminology defined here:

https://en.wikipedia.org/wiki/Alpha_compositing

"A over B" is the default (and existing) behavior. However, recently I find myself needing the "atop" mode as well.

I'm not sure about the use of the other modes, but I just implemented them for the sake of completeness.